### PR TITLE
Handle youtube dimensions for wide screens

### DIFF
--- a/src/pages/music.jsx
+++ b/src/pages/music.jsx
@@ -8,6 +8,31 @@ import { fetchRandomVideo } from 'actions/youtube';
 import DataStates from 'constants/dataStates';
 
 class MusicPage extends Component {
+  static generateYoutubeOptions() {
+    const screenWidth = window.innerWidth;
+    const screenHeight = window.innerHeight;
+    let youtubeWidth;
+    let youtubeHeight;
+
+    if (screenWidth < screenHeight) {
+      youtubeWidth = screenWidth - (2 * 20);          // left right padding of 20px
+      youtubeHeight = screenWidth / (16 / 9);         // 16:9 aspect ratio
+    } else {
+      youtubeHeight = screenHeight - 80 - (2 * 20);   // top down padding of 20px and height height
+      youtubeWidth = screenHeight / (9 / 16);         // 16:9 aspect ratio
+    }
+
+    return {
+      height: youtubeHeight,
+      width: youtubeWidth,
+      playerVars: { // https://developers.google.com/youtube/player_parameters
+        color: 'white',
+        rel: 0,
+        showinfo: 0
+      }
+    };
+  }
+
   constructor(props) {
     super(props);
     this.state = { player: null };
@@ -31,17 +56,7 @@ class MusicPage extends Component {
 
   render() {
     const { video, dataState } = this.props;
-    const screenWidth = window.innerWidth - (2 * 20); // left right padding of 20px
-    const screenHeight = screenWidth / (16 / 9);      // 16:9 aspect ratio
-    const opts = {
-      height: screenHeight,
-      width: screenWidth,
-      playerVars: { // https://developers.google.com/youtube/player_parameters
-        color: 'white',
-        rel: 0,
-        showinfo: 0
-      }
-    };
+    const opts = MusicPage.generateYoutubeOptions();
 
     if (dataState === DataStates.Fetched) {
       return (


### PR DESCRIPTION
Previously, only dimensions for screens with narrow width were handled.
Now, for wide screens, use height as anchor instead so the y-axis for the player does not overflow the viewport.