### PR TITLE
Media query aspect ratio

### DIFF
--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
-import { goToAnchor } from 'react-scrollable-anchor';
+import { goToAnchor, removeHash } from 'react-scrollable-anchor';
 
 export default class Header extends Component {
   static renderHeaderButton(anchor, label) {
     return (
       <button
         className="header-button"
-        onClick={() => goToAnchor(anchor)}
+        onClick={() => { removeHash(); goToAnchor(anchor); }}
       >
         {label}
       </button>

--- a/src/stylesheet.scss
+++ b/src/stylesheet.scss
@@ -34,16 +34,31 @@ button {
   }
 }
 
+/* narrow width */
+@media screen and (max-width: 768px) {
+  .header {
+    padding: 0 50px;
+    width: calc(100vw - 100px);
+  }
+}
+
 .home {
-  display: flex;
   height: $page-height;
-  justify-content: center;
 
   .logo {
     display: block;
     margin: auto;
     height: auto;
     max-width: 100vw;
+  }
+}
+
+@media screen and (min-aspect-ratio: 5/4) {
+  .home {
+    .logo {
+      max-height: $page-height;
+      width: auto;
+    }
   }
 }
 
@@ -132,19 +147,4 @@ button {
 .contact-photo {
   background-color: grey;
   flex: 1;
-}
-
-/* For mobile phones: */
-@media only screen and (max-width: 768px) {
-  .header {
-    padding: 0 50px;
-    width: calc(100vw - 100px);
-  }
-
-  .home {
-    .logo {
-      height: auto;
-      max-width: 100vw;
-    }
-  }
 }


### PR DESCRIPTION
Should be the final prata as the aspect ratio seems to work well with managing the logo size now.

Remove the `#{id}` in the url right before clicking the header buttons so that scrolling works no matter where the user is. Previously you cannot scroll to the same anchor.