### PR TITLE
Fix about page loader

### DIFF
--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -84,7 +84,9 @@ class AboutPage extends Component {
         <PageLoader loaded={dataState === DataStates.Fetched}>
           {this.renderStory()}
         </PageLoader>
-        {this.renderEvents()}
+        <PageLoader loaded={dataState === DataStates.Fetched}>
+          {this.renderEvents()}
+        </PageLoader>
       </div>
     );
   }


### PR DESCRIPTION
Events highlights was fetching data prematurely as it was not wrapped in the loader. Fixed by wrapping it in a separate loader.