### PR TITLE
Always show chrome address bar

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -19,7 +19,7 @@ export default class App extends Component {
 
   render() {
     return (
-      <div>
+      <div className="app">
         <Header />
         {this.props.children}
       </div>

--- a/src/stylesheet.scss
+++ b/src/stylesheet.scss
@@ -9,15 +9,23 @@ $page-height: calc(100vh - 80px);
 $gallery-image-height: calc(100vh - 80px - 75px);
 
 html, body {
+  height: 100%;
   width: 100%;
   margin: 0;
-  overflow-x: hidden;
 }
 
 button {
   background: $background-color;
   border: 0;
   outline: none;
+}
+
+.app {
+  height: 100%;
+  overflow-x: hidden;
+  overflow-y: scroll;
+  position: absolute;
+  width: 100%;
 }
 
 .layout {


### PR DESCRIPTION
The chrome address bar in mobile hides itself when scrolling down, creating a bad experience for users who are actively scrolling.