### PR TITLE
Refine header responsive styling

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -15,12 +15,14 @@ export default class Header extends Component {
 
   render() {
     return (
-      <div className="header">
-        {Header.renderHeaderButton('home', 'HOME')}
-        {Header.renderHeaderButton('about', 'ABOUT')}
-        {Header.renderHeaderButton('music', 'MUSIC')}
-        {Header.renderHeaderButton('gallery', 'GALLERY')}
-        {Header.renderHeaderButton('contact', 'CONTACT')}
+      <div className="header-container">
+        <div className="header">
+          {Header.renderHeaderButton('home', 'HOME')}
+          {Header.renderHeaderButton('about', 'ABOUT')}
+          {Header.renderHeaderButton('music', 'MUSIC')}
+          {Header.renderHeaderButton('gallery', 'GALLERY')}
+          {Header.renderHeaderButton('contact', 'CONTACT')}
+        </div>
       </div>
     );
   }

--- a/src/stylesheet.scss
+++ b/src/stylesheet.scss
@@ -26,17 +26,24 @@ button {
   height: $page-height; 
 }
 
-.header {
-  align-items: center;
+.header-container {
   background: $background-color;
   display: flex;
   height: $header-height;
-  justify-content: space-between;
-  padding: 0 100px;
+  justify-content: center;
   position: fixed;
   top: 0;
-  width: calc(100vw - 200px);
+  width: 100%;
   z-index: 100;
+}
+
+.header {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  // padding: 0 100px;
+  // width: calc(100vw - 200px);
+  width: 70vw;
 
   .header-button {
     font-size: 18pt;
@@ -50,8 +57,11 @@ button {
 /* narrow width */
 @media screen and (max-width: 768px) {
   .header {
-    padding: 0 50px;
-    width: calc(100vw - 100px);
+    width: 90vw;
+
+    .header-button {
+      font-size: 10pt;
+    }
   }
 }
 


### PR DESCRIPTION
- Make font-size for header smaller for narrow screen
- Header is now centered and taking up 70vw (for wide screen) and 90vw (for narrow screen)