### PR TITLE
Update media queries to center gallery images

### DIFF
--- a/src/stylesheet.scss
+++ b/src/stylesheet.scss
@@ -377,24 +377,23 @@ button {
   }
 }
 
-@media screen and (min-aspect-ratio: 10/7) {
+@media screen and (min-width: 1075px) {
   .gallery {
     .slick-slide {
       display: flex;
       justify-content: center;
     }
+  }
+}
 
+@media screen and (min-width: 1150px) {
+  .gallery {
     .slick-next {
       margin-right: 20px;
     }
     
     .slick-prev {
       margin-left: 20px;
-    }
-
-    img {
-      max-height: 70vh;
-      width: auto;
     }
   }
 }


### PR DESCRIPTION
Gallery images were not centered appropriately when screen is already too wide. Updated media queries to detect width as gallery photos have generally fixed widths at the moment.