### PR TITLE
Fix contact us link in about page

### DIFF
--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -1,12 +1,15 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import Scroll from 'react-scroll';
 
 import PageLoader from 'components/PageLoader';
 import { fetchAboutUs } from 'actions/firebase';
 import { generateImageUrl } from 'utils';
 import Months from 'constants/dates';
 import DataStates from 'constants/dataStates';
+
+const scroller = Scroll.scroller;
 
 class AboutPage extends Component {
   static parseEventDate(date) {
@@ -40,6 +43,9 @@ class AboutPage extends Component {
         <div className="story" >
           <div className="about-title">OUR STORY</div>
           <div dangerouslySetInnerHTML={{ __html: story }} />
+          <div className="contact-us">
+            <button onClick={() => scroller.scrollTo('contact')}>CONTACT US</button>
+          </div>
         </div>
       </div>
     );

--- a/src/stylesheet.scss
+++ b/src/stylesheet.scss
@@ -156,10 +156,6 @@ button {
 .about {
   min-height: $page-height;
 
-  a {
-    cursor: default;
-  }
-
   .container {
     align-items: center;
     background-position: center;
@@ -181,12 +177,19 @@ button {
     padding: 0 50px;
     text-align: justify;
 
-    a {
+    .contact-us {
+      display: flex;
+      justify-content: center;
+    }
+
+    button {
+      background: transparent;
       color: $highlight-color;
+      font-size: 20pt;
       text-decoration: none;
     }
 
-    a:hover {
+    button:hover {
       text-decoration: underline;
     }
   }


### PR DESCRIPTION
After moving to `react-scroll` in PR #73 , the linking in about page broke as the web site no longer uses anchors to scroll to the different pages.

As such, a `CONTACT US` button is added at the bottom of the text.