### PR TITLE
Handle errors

### DIFF
--- a/src/actions/firebase.js
+++ b/src/actions/firebase.js
@@ -34,12 +34,16 @@ export function fetchAboutUs() {
       events: cb => database.ref('/events').once('value').then(snapshot => cb(null, snapshot.val())),
       photos: cb => database.ref('/photos').once('value').then(snapshot => cb(null, snapshot.val()))
     }, (err, results) => {
-      dispatch({
-        type: types.FETCH_ABOUT_US_SUCCESS,
-        story: results.story,
-        events: results.events,
-        photos: results.photos
-      });
+      if (err) {
+        dispatch({ type: types.FETCH_ABOUT_US_ERROR });
+      } else {
+        dispatch({
+          type: types.FETCH_ABOUT_US_SUCCESS,
+          story: results.story,
+          events: results.events,
+          photos: results.photos
+        });
+      }
     });
   };
 }

--- a/src/actions/firebase.js
+++ b/src/actions/firebase.js
@@ -48,6 +48,7 @@ export function fetchGallery() {
     dispatch({ type: types.FETCHING_GALLERY });
 
     database.ref('/gallery').once('value')
-      .then(snapshot => dispatch({ type: types.FETCH_GALLERY_SUCCESS, photos: snapshot.val() }));
+      .then(snapshot => dispatch({ type: types.FETCH_GALLERY_SUCCESS, photos: snapshot.val() }))
+      .catch(() => dispatch({ type: types.FETCH_GALLERY_ERROR }));
   };
 }

--- a/src/actions/firebase.js
+++ b/src/actions/firebase.js
@@ -20,7 +20,8 @@ export function fetchUpcomingEvent() {
     dispatch({ type: types.FETCHING_UPCOMING_EVENT });
 
     database.ref('/upcoming-event').once('value')
-      .then(snapshot => dispatch({ type: types.FETCH_UPCOMING_EVENT_SUCCESS, event: snapshot.val() }));
+      .then(snapshot => dispatch({ type: types.FETCH_UPCOMING_EVENT_SUCCESS, event: snapshot.val() }))
+      .catch(() => dispatch({ type: types.FETCH_UPCOMING_EVENT_ERROR }));
   };
 }
 

--- a/src/actions/youtube.js
+++ b/src/actions/youtube.js
@@ -3,7 +3,7 @@ import types from 'actions/types';
 
 const YOUTUBE_PLAYLISTS_URL = 'https://www.googleapis.com/youtube/v3/playlistItems';
 
-export function fetchRandomVideo() {
+export default function fetchRandomVideo() {
   return (dispatch) => {
     dispatch({ type: types.FETCHING_YOUTUBE_VIDEO });
 
@@ -33,6 +33,7 @@ export function fetchRandomVideo() {
           video: randomVideoId,
           title: randomVideoTitle
         });
-      });
+      })
+      .catch(() => dispatch({ type: types.FETCH_YOUTUBE_VIDEO_ERROR }));
   };
 }

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -8,6 +8,8 @@ import { generateImageUrl } from 'utils';
 import Months from 'constants/dates';
 import DataStates from 'constants/dataStates';
 
+const ABOUT_US_ERROR_MESSAGE = 'There seems to be an error. Please refresh or try again later.';
+
 class AboutPage extends Component {
   static parseEventDate(date) {
     const tokenisedDate = date.split('-');
@@ -32,8 +34,13 @@ class AboutPage extends Component {
   }
 
   renderStory() {
-    const { story, photos } = this.props;
+    const { story, photos, dataState } = this.props;
     const storyPhoto = generateImageUrl(photos.story, 'w_1000');
+
+    if (dataState === DataStates.Error) {
+      return <div className="container">{ABOUT_US_ERROR_MESSAGE}</div>;
+    }
+
     /* eslint-disable react/no-danger */
     return (
       <div className="container" style={{ backgroundImage: `url(${storyPhoto})` }}>
@@ -74,8 +81,13 @@ class AboutPage extends Component {
   }
 
   renderEvents() {
-    const { photos } = this.props;
+    const { photos, dataState } = this.props;
     const eventsPhoto = generateImageUrl(photos.events, 'w_1000');
+
+    if (dataState === DataStates.Error) {
+      return <div className="container">{ABOUT_US_ERROR_MESSAGE}</div>;
+    }
+
     return (
       <div className="container" style={{ backgroundImage: `url(${eventsPhoto})` }}>
         <div className="events">
@@ -92,10 +104,10 @@ class AboutPage extends Component {
     const { dataState } = this.props;
     return (
       <div className="about">
-        <PageLoader loaded={dataState === DataStates.Fetched}>
+        <PageLoader loaded={dataState !== DataStates.Fetching}>
           {this.renderStory()}
         </PageLoader>
-        <PageLoader loaded={dataState === DataStates.Fetched}>
+        <PageLoader loaded={dataState !== DataStates.Fetching}>
           {this.renderEvents()}
         </PageLoader>
       </div>

--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -8,13 +8,15 @@ import { fetchGallery } from 'actions/firebase';
 import { generateImageUrl } from 'utils';
 import DataStates from 'constants/dataStates';
 
+const GALLERY_ERROR_MESSAGE = 'There seems to be an error. Please refresh or try again later.';
+
 class GalleryPage extends Component {
   componentDidMount() {
     const { fetchPhotos } = this.props;
     fetchPhotos();
   }
 
-  render() {
+  renderContents() {
     const { gallery, dataState } = this.props;
     const settings = {
       arrows: true,
@@ -25,17 +27,29 @@ class GalleryPage extends Component {
       slidesToShow: 1,
       slidesToScroll: 1
     };
+
+    if (dataState === DataStates.Error) {
+      return <div>{GALLERY_ERROR_MESSAGE}</div>;
+    }
+
+    return (
+      <Slider {...settings}>
+        {gallery.map(photo => (
+          <div key={photo}>
+            <img src={generateImageUrl(photo, 'q_50,w_1000,ar_16:9,c_fill')} alt="gallery" />
+          </div>
+        ))}
+      </Slider>
+    );
+  }
+
+  render() {
+    const { dataState } = this.props;
     return (
       <div className="gallery">
         <div className="container">
-          <PageLoader className="loader" loaded={dataState === DataStates.Fetched}>
-            <Slider {...settings}>
-              {gallery.map(photo => (
-                <div key={photo}>
-                  <img src={generateImageUrl(photo, 'q_50,w_1000,ar_16:9,c_fill')} alt="gallery" />
-                </div>
-              ))}
-            </Slider>
+          <PageLoader className="loader" loaded={dataState !== DataStates.Fetching}>
+            {this.renderContents()}
           </PageLoader>
         </div>
       </div>

--- a/src/pages/Music.jsx
+++ b/src/pages/Music.jsx
@@ -5,11 +5,12 @@ import { connect } from 'react-redux';
 import Youtube from 'react-youtube';
 
 import PageLoader from 'components/PageLoader';
-import { fetchRandomVideo } from 'actions/youtube';
+import fetchRandomVideo from 'actions/youtube';
 import DataStates from 'constants/dataStates';
 import YoutubeIcon from 'images/youtube.svg';
 
 const HEADER_BAR_HEIGHT = 60;
+const YOUTUBE_ERROR_MESSAGE = 'There seems to be an error. Please refresh or try again later.';
 
 class MusicPage extends Component {
   static generateYoutubeOptions() {
@@ -63,23 +64,36 @@ class MusicPage extends Component {
     }
   }
 
-  render() {
+  renderContents() {
     const { video, title, dataState } = this.props;
     const opts = MusicPage.generateYoutubeOptions();
 
+    if (dataState === DataStates.Error) {
+      return <div>{YOUTUBE_ERROR_MESSAGE}</div>;
+    }
+
+    return (
+      <div>
+        <div className="player-title">{title}</div>
+        <div className="player-container">
+          <Youtube videoId={video} opts={opts} onReady={event => this.setState({ player: event.target })} />
+        </div>
+        <div className="player-more-info">
+          <button onClick={() => window.open(process.env.YOUTUBE_CHANNEL)}>
+            Visit our YouTube page
+            <YoutubeIcon className="youtube-icon" />
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  render() {
+    const { dataState } = this.props;
     return (
       <div className="music">
-        <PageLoader loaded={dataState === DataStates.Fetched}>
-          <div className="player-title">{title}</div>
-          <div className="player-container">
-            <Youtube videoId={video} opts={opts} onReady={event => this.setState({ player: event.target })} />
-          </div>
-          <div className="player-more-info">
-            <button onClick={() => window.open(process.env.YOUTUBE_CHANNEL)}>
-              Visit our YouTube page
-              <YoutubeIcon className="youtube-icon" />
-            </button>
-          </div>
+        <PageLoader loaded={dataState !== DataStates.Fetching}>
+          {this.renderContents()}
         </PageLoader>
       </div>
     );


### PR DESCRIPTION
Each page with fetch requests now handles it's own errors. If erroneous, display a generic error message for each of the pages.

Fixes #62 