### PR TITLE
Set max width on iphone 6 plus styling

### DIFF
--- a/src/styles/about.scss
+++ b/src/styles/about.scss
@@ -180,7 +180,7 @@
 }
 
 /* mobile landscape iphone 6 plus - adjust font sizes */
-@media screen and (min-aspect-ratio: 17/10) and (min-height: 376px) {
+@media screen and (min-aspect-ratio: 17/10) and (min-height: 376px) and (max-width: 736px) {
   .about {
     .about-title {
       font-size: 24pt

--- a/src/styles/music.scss
+++ b/src/styles/music.scss
@@ -86,7 +86,7 @@
 }
 
 /* mobile landscape iphone 6 and above - adjust content to fit */
-@media screen and (min-aspect-ratio: 17/10) and (min-height: 321px) {
+@media screen and (min-aspect-ratio: 17/10) and (min-height: 321px) and (max-width: 736px) {
   .music {
     padding-top: 10px;
 


### PR DESCRIPTION
Previously, setting aspect ratio and min-height only results in mobile styling being applied on large high aspect-ratio screens when said stylings were only meant for iphone 6 plus sized phones.

Added max-width condition to rectify.